### PR TITLE
Fix bugs and add support for async_client

### DIFF
--- a/langchain_xinference/chat_models.py
+++ b/langchain_xinference/chat_models.py
@@ -507,10 +507,7 @@ class ChatXinference(BaseChatModel):
         return built_tool_calls
 
     def _set_tools(self, tools, tool_choice):
-        if self.tools is None:
-            self.tools = tools
-        else:
-            self.tools += tools
+        self.tools = tools
         self.tool_choice = tool_choice
 
     def bind_tools(

--- a/langchain_xinference/reranks.py
+++ b/langchain_xinference/reranks.py
@@ -1,14 +1,16 @@
 # python
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, AsyncIterator, Dict, Iterator, Optional, Sequence, Union
 
+import requests
 from langchain_core.documents import BaseDocumentCompressor, Document
-from pydantic import ConfigDict, model_validator
+from pydantic import ConfigDict
 
 
 class XinferenceRerank(BaseDocumentCompressor):
     """Document compressor that uses `Xinference Rerank API`."""
 
     client: Any = None
+    async_client: Any = None
     server_url: Optional[str] = None
     model_uid: Optional[str] = None
     top_n: Optional[int] = 3
@@ -18,33 +20,61 @@ class XinferenceRerank(BaseDocumentCompressor):
         extra="forbid",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def validate_environment(cls, values: Dict) -> Dict:
+    def __init__(
+        self,
+        server_url: Optional[str] = None,
+        model_uid: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
         try:
-            from xinference.client import RESTfulClient
+            from xinference.client import AsyncRESTfulClient, RESTfulClient
         except ImportError:
             try:
-                from xinference_client import RESTfulClient
+                from xinference_client import AsyncRESTfulClient, RESTfulClient
             except ImportError as e:
                 raise ImportError(
                     "Could not import RESTfulClient from xinference. Please install it"
                     " with `pip install xinference` or `pip install xinference_client`."
                 ) from e
 
-        server_url = values.get("server_url")
-        model_uid = values.get("model_uid")
+        super().__init__(
+            **{  # type: ignore[arg-type]
+                "server_url": server_url,
+                "model_uid": model_uid,
+            }
+        )
 
-        if server_url is None:
+        if self.server_url is None:
             raise ValueError("Please provide server URL")
 
-        if model_uid is None:
+        if self.model_uid is None:
             raise ValueError("Please provide the model UID")
 
-        values["client"] = RESTfulClient(server_url)
-        return values
+        self._headers: Dict[str, str] = {}
+        self._cluster_authed = False
+        self._check_cluster_authenticated()
+        if api_key is not None and self._cluster_authed:
+            self._headers["Authorization"] = f"Bearer {api_key}"
 
-    def rerank(
+        self.client = RESTfulClient(server_url, api_key)
+        try:
+            self.async_client = AsyncRESTfulClient(server_url, api_key)
+        except RuntimeError:
+            self.async_client = None
+
+    def _check_cluster_authenticated(self) -> None:
+        url = f"{self.server_url}/v1/cluster/auth"
+        response = requests.get(url)
+        if response.status_code == 404:
+            self._cluster_authed = False
+        else:
+            if response.status_code != 200:
+                raise RuntimeError(f"Failed to get cluster information, detail: {response.json()['detail']}")
+            response_data = response.json()
+
+            self._cluster_authed = bool(response_data["auth"])
+
+    def _rerank(
         self,
         documents: Sequence[Union[str, Document, dict]],
         query: str,
@@ -54,25 +84,59 @@ class XinferenceRerank(BaseDocumentCompressor):
         return_documents: Optional[bool] = None,
         return_len: Optional[bool] = None,
         **kwargs,
-    ) -> List[Dict[str, Any]]:
+    ) -> Iterator[Dict[str, Any]]:
         if not documents:
-            return []
-        docs = [doc.page_content if isinstance(doc, Document) else doc for doc in documents]
-        model = self.client.get_model(self.model_uid)
-        top_n = top_n if (top_n is not None and top_n > 0) else self.top_n
-        results = model.rerank(
-            documents=docs,
-            query=query,
-            top_n=top_n,
-            max_chunks_per_doc=max_chunks_per_doc,
-            return_documents=return_documents,
-            return_len=return_len,
-            **kwargs,
-        )
-        if hasattr(results, "results"):
-            results = results.results
-        items = results["results"]
-        return [{"index": r["index"], "relevance_score": r["relevance_score"]} for r in items]
+            items = []
+        else:
+            docs = [doc.page_content if isinstance(doc, Document) else doc for doc in documents]
+            model = self.client.get_model(self.model_uid)
+            top_n = top_n if (top_n is not None and top_n > 0) else self.top_n
+            results = model.rerank(
+                documents=docs,
+                query=query,
+                top_n=top_n,
+                max_chunks_per_doc=max_chunks_per_doc,
+                return_documents=return_documents,
+                return_len=return_len,
+                **kwargs,
+            )
+            if hasattr(results, "results"):
+                results = results.results
+            items = results["results"]
+        for r in items:
+            yield {"index": r["index"], "relevance_score": r["relevance_score"]}
+
+    async def _arerank(
+        self,
+        documents: Sequence[Union[str, Document, dict]],
+        query: str,
+        *,
+        top_n: Optional[int] = None,
+        max_chunks_per_doc: Optional[int] = None,
+        return_documents: Optional[bool] = None,
+        return_len: Optional[bool] = None,
+        **kwargs,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        if not documents:
+            items = []
+        else:
+            docs = [doc.page_content if isinstance(doc, Document) else doc for doc in documents]
+            model = await self.async_client.get_model(self.model_uid)
+            top_n = top_n if (top_n is not None and top_n > 0) else self.top_n
+            results = await model.rerank(
+                documents=docs,
+                query=query,
+                top_n=top_n,
+                max_chunks_per_doc=max_chunks_per_doc,
+                return_documents=return_documents,
+                return_len=return_len,
+                **kwargs,
+            )
+            if hasattr(results, "results"):
+                results = results.results
+            items = results["results"]
+        for r in items:
+            yield {"index": r["index"], "relevance_score": r["relevance_score"]}
 
     def compress_documents(
         self,
@@ -83,7 +147,23 @@ class XinferenceRerank(BaseDocumentCompressor):
         from copy import deepcopy
 
         compressed = []
-        for res in self.rerank(documents, query):
+        for res in self._rerank(documents, query):
+            doc = documents[res["index"]]
+            doc_copy = Document(doc.page_content, metadata=deepcopy(doc.metadata))
+            doc_copy.metadata["relevance_score"] = res["relevance_score"]
+            compressed.append(doc_copy)
+        return compressed
+
+    async def acompress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks=None,
+    ) -> Sequence[Document]:
+        from copy import deepcopy
+
+        compressed = []
+        async for res in self._arerank(documents, query):
             doc = documents[res["index"]]
             doc_copy = Document(doc.page_content, metadata=deepcopy(doc.metadata))
             doc_copy.metadata["relevance_score"] = res["relevance_score"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "langchain-xinference"
-version = "0.1.2.post1"
+version = "0.1.2"
 description = "An integration package connecting Xinference and LangChain"
 authors = []
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10,<4.0"
 dependencies = [
     "langchain-core>=0.3.15,<0.4.0",
     "aiohttp>=3.8.0,<4.0.0",
-    "xinference-client>=1.4.0,<2.0.0",
+    "xinference-client>=1.7.1,<2.0.0",
     "pydantic>=2.10.0,<3.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "langchain-xinference"
-version = "0.1.1"
+version = "0.1.2.post1"
 description = "An integration package connecting Xinference and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
修复了一些诸如qwen3的思考内容没有输出(放在additional_kwargs["reasoning_content"]里了)的bug，以及把上游异步客户端的支持加上了

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

全面支持 Xinference 异步 RESTful 客户端，涵盖聊天模型、LLM、重排序和嵌入，修复流式响应中缺失的推理内容，更新各种流以使用一致的消息转换，标准化 generate_config 合并和流式行为，并使用更新的依赖项来更新包版本。

新特性：
- 引入 async_client 字段，并使用聊天、llm、重排序和嵌入类的回退来初始化 AsyncRESTfulClient
- 添加异步方法（_agenerate、_acall、_astream、_arerank、aembed_documents、aembed_query）以公开流式和非流式异步 API

Bug 修复：
- 提取 "reasoning_content" 并将其传播到 additional_kwargs 中，用于流式 AIMessageChunks
- 在 generation_info 中包含 "length" finish_reason，并切换到 convert_to_openai_messages 以修复消息格式问题

增强功能：
- 重构工具绑定以进行追加而不是覆盖，并统一聊天聚合中的消息字典转换
- 将重排序转换为流式迭代器，并标准化 generate_config 合并和停止处理
- 在绑定工具时使用 deepcopy，并在所有调用中一致地合并客户端 model_kwargs

构建：
- 将包版本提升至 0.1.2
- 将 xinference-client 依赖项升级至 >=1.7.1,<2.0.0

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable full support for Xinference async RESTful clients across chat models, LLMs, reranking, and embeddings, fix missing reasoning content in streamed responses, update various streams to use consistent message conversion, standardize generate_config merging and streaming behavior, and bump package version with updated dependencies.

New Features:
- Introduce async_client fields and initialize AsyncRESTfulClient with fallback for chat, llm, rerank, and embedding classes
- Add asynchronous methods (_agenerate, _acall, _astream, _arerank, aembed_documents, aembed_query) to expose streaming and non-streaming async APIs

Bug Fixes:
- Extract and propagate "reasoning_content" into additional_kwargs for streamed AIMessageChunks
- Include "length" finish_reason in generation_info and switch to convert_to_openai_messages to fix message formatting issues

Enhancements:
- Refactor tool binding to append rather than overwrite and unify message dict conversion in chat aggregation
- Convert rerank to streaming iterator and standardize generate_config merging and stop handling
- Use deepcopy when binding tools and merge client model_kwargs consistently across calls

Build:
- Bump package version to 0.1.2
- Upgrade xinference-client dependency to >=1.7.1,<2.0.0

</details>